### PR TITLE
Update feedstock for 0.6.0 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "documenteer" %}  {# PyPI name #}
-{% set version = "0.5.6" %}
+{% set version = "0.6.0" %}
 
 package:
   name: "lsst-documenteer"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: "06fbceb7324ed3b00f012b90b2da0e0aff9faab7957d6d7c5f09cc5a3069c9cf"
+  sha256: "3325f06e3a725cb485bec22f8ebe302e4ca721465cac493f3548b9abef96e88b"
 
 build:
   number: 0
@@ -29,14 +29,13 @@ outputs:
         - setuptools
         - setuptools_scm
       run:
-        - python >=3.6
-        - sphinx >=1.6
+        - python >=3.7
+        - sphinx >=2.0
         - click
         - gitpython
         - pyyaml
         - requests
-        - sphinx-prompt
-        - pybtex
+        - sphinxcontrib-bibtex
     test:
       imports:
         - documenteer
@@ -58,9 +57,8 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("documenteer", exact=True) }}
-        - sphinx >=1.7.0,<1.8.0
-        - lsst-dd-rtd-theme ==0.2.3
-        - sphinxcontrib-bibtex ==0.4.0
+        - lsst-dd-rtd-theme >=0.2.3,<0.3.0
+        - sphinx-prompt
     test:
       commands:
         - refresh-lsst-bib --help
@@ -77,13 +75,14 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("documenteer", exact=True) }}
-        - sphinx >=1.7.0,<1.8.0
         - lsst-sphinx-bootstrap-theme >=0.2.0,<0.3.0
-        - numpydoc >=0.8.0,<0.9.0
-        - sphinx-automodapi >=0.7,<0.8
-        - breathe
-        - sphinx-jinja ==1.1.1
-        - sphinxcontrib-autoprogram >=0.1.5,<0.2.0
+        - sphinx-prompt
+        - numpydoc
+        - sphinx-automodapi
+        - sphinx-jinja
+        - sphinx-click
+        - sphinxcontrib-autoprogram
+        - sphinxcontrib-doxylink
     test:
       commands:
          - stack-docs --help


### PR DESCRIPTION
Updates to the recipe for the 0.6.0 documenteer release.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
